### PR TITLE
Fix logout callback handling

### DIFF
--- a/routes/auth.js
+++ b/routes/auth.js
@@ -31,10 +31,12 @@ router.post('/login',
 );
 
 // çıkış
-router.get('/logout', (req, res) => {
-  req.logout();
-  req.flash('success','Çıkış yapıldı');
-  res.redirect('/');
+router.get('/logout', (req, res, next) => {
+  req.logout(err => {
+    if (err) { return next(err); }
+    req.flash('success', 'Çıkış yapıldı');
+    res.redirect('/');
+  });
 });
 
 module.exports = router;


### PR DESCRIPTION
## Summary
- fix logout route to handle Passport 0.7 callback

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_683fde8a363c83249d45a316be72793f